### PR TITLE
Add native macOS Apple Silicon support

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,676 @@
+# VoiceChanger (VCClient) - Agent Documentation
+
+## Project Overview
+
+VoiceChanger is a **real-time voice conversion application** that uses AI models to transform human speech in real-time. It supports multiple voice conversion models and operates in both standalone and network-distributed configurations.
+
+- **Repository:** https://github.com/w-okada/voice-changer
+- **Version:** v2.0.78-beta
+- **License:** ISC (with custom licenses for specific voice models)
+- **Primary Language:** Japanese (with i18n support for English, Korean, Chinese, etc.)
+
+### Supported Voice Models
+| Model | Description | Status |
+|-------|-------------|--------|
+| RVC | Retrieval-based Voice Conversion | Primary, fully supported |
+| Beatrice v2 | Commercial voice model | Static slot only |
+| MMVC v13/v15 | Japanese voice conversion | Supported |
+| so-vits-svc 4.0 | Singing voice synthesis | Supported |
+| DDSP-SVC | Differentiable DSP | Supported |
+| Diffusion-SVC | Diffusion-based conversion | Supported |
+| LLVC | Lightweight conversion | Supported |
+| EasyVC | Simplified RVC variant | Supported |
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Browser/Client                               │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ React Demo App (client/demo)                                 │   │
+│  │   └── VoiceChangerClient (client/lib)                       │   │
+│  │         ├── ServerRestClient (REST API)                     │   │
+│  │         └── VoiceChangerWorkletNode (AudioWorklet)          │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │ HTTP/WebSocket
+┌──────────────────────────────▼──────────────────────────────────────┐
+│                         Python Server                                │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ MMVCServerSIO.py (Entry Point)                              │   │
+│  │   ├── MMVC_Rest (FastAPI REST endpoints)                    │   │
+│  │   └── MMVC_SocketIOApp (Socket.IO real-time streaming)      │   │
+│  │                                                             │   │
+│  │ VoiceChangerManager (Singleton orchestrator)                │   │
+│  │   └── ModelSlotManager                                      │   │
+│  │         └── Model Implementations (RVC, Beatrice, etc.)     │   │
+│  │               ├── Inferencers (PyTorch, ONNX)               │   │
+│  │               ├── Embedders (ContentVec, Hubert, Whisper)   │   │
+│  │               └── PitchExtractors (crepe, rmvpe, fcpe)      │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Audio Processing Flow
+```
+Browser Mic → AudioContext → VoiceChangerWorkletNode
+    ↓
+REST/Socket.IO → Python Server
+    ↓
+VoiceChangerManager → Model.inference()
+    ↓
+Response → VoiceChangerWorkletNode → Browser Output
+```
+
+### Sample Rate Chain
+```
+Input (48kHz) → Resample (16kHz) → Model Processing → Model Output (40kHz) → Resample (48kHz) → Output
+```
+
+---
+
+## Directory Structure
+
+```
+voice-changer/
+├── server/                     # Python backend (FastAPI + Socket.IO)
+│   ├── MMVCServerSIO.py       # MAIN ENTRY POINT
+│   ├── requirements.txt       # Python dependencies (Linux/Windows)
+│   ├── requirements-mac.txt   # Mac-specific dependencies
+│   ├── setup-mac.sh           # Mac conda environment setup
+│   ├── start-mac.sh           # Mac server startup script
+│   ├── const.py               # Types, enums, constants
+│   ├── Exceptions.py          # Custom exception classes
+│   ├── restapi/               # REST API endpoints
+│   │   ├── MMVC_Rest.py       # FastAPI app setup
+│   │   ├── MMVC_Rest_VoiceChanger.py  # Voice conversion endpoints
+│   │   └── MMVC_Rest_Fileuploader.py  # File upload & model management
+│   ├── sio/                   # Socket.IO server
+│   │   ├── MMVC_SocketIOApp.py
+│   │   ├── MMVC_SocketIOServer.py
+│   │   └── MMVC_Namespace.py  # Real-time audio handler
+│   ├── data/                  # Data structures
+│   │   └── ModelSlot.py       # Model slot definitions
+│   └── voice_changer/         # Core voice conversion logic
+│       ├── VoiceChangerManager.py    # Main orchestrator (singleton)
+│       ├── VoiceChanger.py           # V1 inference pipeline
+│       ├── VoiceChangerV2.py         # V2 optimized pipeline
+│       ├── ModelSlotManager.py       # Model slot handling
+│       ├── RVC/                      # RVC model implementation
+│       │   ├── RVC.py, RVCr2.py      # RVC entry points
+│       │   ├── RVCSettings.py        # RVC configuration
+│       │   ├── pipeline/             # Processing pipeline
+│       │   │   ├── Pipeline.py       # Main pipeline class
+│       │   │   └── PipelineGenerator.py  # Pipeline factory
+│       │   ├── inferencer/           # Inference backends
+│       │   │   ├── RVCInferencerv2.py
+│       │   │   ├── RVCInferencerv2Nono.py  # No-f0 models
+│       │   │   └── rvc_models/       # Model architectures
+│       │   ├── embedder/             # Feature extractors
+│       │   │   ├── EmbedderManager.py
+│       │   │   ├── FairseqHubert.py  # HuBERT embedder
+│       │   │   ├── FairseqContentvec.py
+│       │   │   └── Whisper.py
+│       │   ├── pitchExtractor/       # Pitch detection
+│       │   │   ├── PitchExtractorManager.py
+│       │   │   ├── RMVPEPitchExtractor.py
+│       │   │   └── CrepePitchExtractor.py
+│       │   └── deviceManager/        # GPU/CPU management
+│       │       └── DeviceManager.py
+│       ├── Beatrice/                 # Beatrice model
+│       ├── DDSP_SVC/                 # DDSP-SVC model
+│       ├── DiffusionSVC/             # Diffusion-SVC model
+│       ├── SoVitsSvc40/              # so-vits-svc model
+│       ├── LLVC/                     # LLVC model
+│       ├── EasyVC/                   # EasyVC model
+│       └── Local/                    # Local device audio I/O
+│           └── ServerDevice.py
+│
+├── client/                    # TypeScript/React frontend
+│   ├── lib/                   # Reusable client library
+│   │   ├── package.json
+│   │   ├── src/
+│   │   │   ├── VoiceChangerClient.ts      # Main client class
+│   │   │   ├── client/
+│   │   │   │   ├── ServerRestClient.ts    # REST communication
+│   │   │   │   └── VoiceChangerWorkletNode.ts  # Audio processing
+│   │   │   └── const.ts                   # Types and constants
+│   │   └── worklet/           # AudioWorklet code
+│   │
+│   └── demo/                  # Demo web application
+│       ├── package.json
+│       ├── src/
+│       │   ├── 000_index.tsx  # React entry point
+│       │   ├── 001_provider/  # React context providers
+│       │   ├── 001_globalHooks/  # Global state hooks
+│       │   └── components/    # UI components
+│       └── public/            # Static assets
+│
+├── recorder/                  # Voice recording UI (separate app)
+├── docker/                    # Docker build files
+├── docker_vcclient/          # VCClient Docker image
+├── docker_trainer/           # Training Docker image
+├── docker-compose.yml        # Multi-container orchestration
+├── tutorials/                 # User documentation
+├── docs_i18n/                # Internationalized documentation
+├── README_mac.md             # Mac-specific documentation
+└── Claude.md                 # This file (agent documentation)
+```
+
+---
+
+## Key Files Reference
+
+### Server Core
+| File | Purpose |
+|------|---------|
+| `server/MMVCServerSIO.py` | Server entry point - argument parsing, startup, HTTPS setup |
+| `server/const.py` | Type definitions (`VoiceChangerType`, `PitchExtractorType`, `EmbedderType`) |
+| `server/Exceptions.py` | Custom exceptions (`NoModeLoadedException`, `HalfPrecisionChangingException`) |
+| `server/voice_changer/VoiceChangerManager.py` | Singleton orchestrator for all models |
+| `server/voice_changer/VoiceChanger.py` | Audio processing with SOLA buffering |
+| `server/voice_changer/ModelSlotManager.py` | Model slot management (up to 500 slots) |
+
+### RVC Implementation
+| File | Purpose |
+|------|---------|
+| `server/voice_changer/RVC/RVCr2.py` | RVC v2 model entry point |
+| `server/voice_changer/RVC/pipeline/Pipeline.py` | Audio processing pipeline |
+| `server/voice_changer/RVC/pipeline/PipelineGenerator.py` | Pipeline factory (with Mac CPU fallback) |
+| `server/voice_changer/RVC/embedder/FairseqHubert.py` | HuBERT feature extraction |
+| `server/voice_changer/RVC/inferencer/RVCInferencerv2Nono.py` | No-f0 model inference |
+| `server/voice_changer/RVC/deviceManager/DeviceManager.py` | CUDA/MPS/CPU device selection |
+
+### REST API
+| File | Purpose |
+|------|---------|
+| `server/restapi/MMVC_Rest.py` | FastAPI app factory with static file mounting |
+| `server/restapi/MMVC_Rest_VoiceChanger.py` | `/test` endpoint for voice conversion |
+| `server/restapi/MMVC_Rest_Fileuploader.py` | File upload, model loading, settings |
+
+### Client
+| File | Purpose |
+|------|---------|
+| `client/lib/src/VoiceChangerClient.ts` | Main client class |
+| `client/lib/src/client/VoiceChangerWorkletNode.ts` | Real-time audio processing |
+| `client/demo/src/000_index.tsx` | Demo app entry point |
+
+---
+
+## API Endpoints
+
+### Voice Conversion
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/test` | POST | Convert audio frame (base64 encoded) |
+
+### File Management
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/upload_file` | POST | Upload model file chunks |
+| `/concat_uploaded_file` | POST | Concatenate uploaded chunks |
+| `/load_model` | POST | Load model into slot |
+
+### Settings & Info
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/info` | GET | Get current system state |
+| `/performance` | GET | Get performance metrics |
+| `/update_settings` | POST | Update voice changer settings |
+
+### Model Management
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/merge_model` | POST | Merge multiple models |
+| `/update_model_info` | POST | Update model metadata |
+| `/onnx` | GET | Export model to ONNX |
+
+### Socket.IO Events
+| Event | Direction | Description |
+|-------|-----------|-------------|
+| `connect` | Client→Server | Client connects |
+| `request_message` | Client→Server | Send audio for conversion |
+| `response` | Server→Client | Receive converted audio |
+| `disconnect` | Client→Server | Client disconnects |
+
+---
+
+## Development Commands
+
+### Server (Python)
+
+#### Linux/Windows Setup
+```bash
+# Setup environment (requires Anaconda)
+conda create -n vcclient-dev python=3.10
+conda activate vcclient-dev
+
+# Install dependencies
+cd server
+pip install -r requirements.txt
+
+# Run server
+python3 MMVCServerSIO.py -p 18888 --https true \
+    --content_vec_500 pretrain/checkpoint_best_legacy_500.pt \
+    --hubert_base pretrain/hubert_base.pt \
+    --model_dir model_dir
+```
+
+#### macOS Setup (Apple Silicon)
+```bash
+# Navigate to server directory
+cd server
+
+# Run setup script (creates conda environment)
+./setup-mac.sh
+
+# Start the server
+./start-mac.sh
+
+# Or with custom port
+PORT=8080 ./start-mac.sh
+```
+
+### Client (TypeScript/React)
+```bash
+# Build client library
+cd client/lib
+npm install
+npm run build:dev
+
+# Run demo app with dev server
+cd client/demo
+npm install
+npm run build:dev
+npm start
+```
+
+### Docker
+```bash
+# Build VCClient image
+npm run build:docker:vcclient
+
+# Run with docker-compose
+docker-compose up
+```
+
+---
+
+## Type Definitions
+
+```python
+# server/const.py
+
+VoiceChangerType = Literal[
+    "MMVCv13", "MMVCv15", "so-vits-svc-40", "DDSP-SVC",
+    "RVC", "Diffusion-SVC", "Beatrice", "LLVC", "EasyVC"
+]
+
+PitchExtractorType = Literal[
+    "harvest", "dio", "crepe", "crepe_full", "crepe_tiny",
+    "rmvpe", "rmvpe_onnx", "fcpe"
+]
+
+EmbedderType = Literal[
+    "hubert_base", "contentvec", "whisper"
+]
+```
+
+---
+
+## Important Patterns
+
+### 1. Protocol-Based Model Interface
+Models implement `VoiceChangerModel` Protocol (not inheritance):
+```python
+# server/voice_changer/utils/VoiceChangerModel.py
+class VoiceChangerModel(Protocol):
+    def loadModel(settings: LoadModelParams) -> None
+    def inference(data: Any, settings: InferenceParams) -> Any
+    def generate_input(data: Any) -> Tuple[Any, int, Any]
+    def get_processing_sampling_rate() -> int
+    def update_settings(settings: ServerSettings) -> None
+```
+
+### 2. Singleton Managers
+- `VoiceChangerManager` - Single instance manages all model operations
+- `ModelSlotManager` - Manages model slots for quick switching
+- `DeviceManager` - GPU/CPU device selection
+
+### 3. V1 vs V2 Pipeline
+- `VoiceChanger` (V1): Resampling in orchestrator
+- `VoiceChangerV2`: Resampling moved to model layer (more efficient)
+
+### 4. AudioWorklet Processing
+Client uses Web Audio API AudioWorklet for low-latency real-time processing.
+
+### 5. Dual Communication
+- REST API: File operations, configuration
+- Socket.IO: Real-time audio streaming
+
+### 6. Model Slot System
+- Up to 500 model slots for quick switching
+- Each slot stores: model files, configuration, speaker info
+- Metadata stored as JSON in `model_dir/{slotIndex}/params.json`
+
+---
+
+## RVC Model Types
+
+### f0 vs nono Models
+| Type | F0 Support | Pitch Shifting | Use Case |
+|------|------------|----------------|----------|
+| **f0 models** | Yes | Supports "tran" parameter | Natural voice conversion with pitch control |
+| **nono models** | No | Not supported | Timbre conversion only, faster |
+
+### Inferencer Selection
+- `RVCInferencerv2` - Standard f0 models
+- `RVCInferencerv2Nono` - No-f0 models
+- `OnnxRVCInferencer` - ONNX optimized inference
+
+---
+
+## macOS (Apple Silicon) Support
+
+### Overview
+Voice-Changer supports macOS with Apple Silicon (M1/M2/M3/M4) using CPU-based inference. MPS (Metal Performance Shaders) is detected but **not used** for RVC inference due to compatibility issues.
+
+### Setup Files
+| File | Purpose |
+|------|---------|
+| `server/requirements-mac.txt` | Mac-specific dependencies |
+| `server/setup-mac.sh` | Conda environment setup script |
+| `server/start-mac.sh` | Server startup script |
+| `README_mac.md` | Mac-specific documentation |
+
+### Key Differences from Linux/Windows
+| Component | Linux/Windows | macOS |
+|-----------|---------------|-------|
+| GPU | NVIDIA CUDA | CPU (MPS detected but not used) |
+| ONNX Runtime | `onnxruntime-gpu` | `onnxruntime` (CPU) |
+| Half Precision | FP16 on supported GPUs | FP32 only |
+| Fairseq | Standard pip install | Custom fork required |
+
+### macOS Dependencies
+```txt
+# requirements-mac.txt key differences:
+onnxruntime==1.16.0              # CPU version (not onnxruntime-gpu)
+fairseq @ git+https://github.com/brandonkovacs/fairseq.git  # Mac-compatible fork
+pyworld==0.3.5                   # Pitch extraction
+```
+
+### Quick Start (macOS)
+```bash
+# 1. Navigate to server directory
+cd server
+
+# 2. Run setup script (creates conda environment 'vcclient')
+./setup-mac.sh
+
+# 3. Start the server
+./start-mac.sh
+
+# Web UI available at: https://localhost:18888
+```
+
+### Environment Variables
+```bash
+# Set in start-mac.sh
+export PYTORCH_ENABLE_MPS_FALLBACK=1  # Required for unsupported MPS ops
+```
+
+---
+
+## macOS MPS Compatibility Issues (RESOLVED)
+
+### Problem
+RVC inference on MPS (Metal Performance Shaders) produced garbage audio - a repeating "ahhhh" sound instead of proper voice conversion. The same models worked correctly on Linux with CUDA.
+
+### Root Cause
+The MPS backend produces incorrect numerical results for certain operations used in the RVC pipeline:
+1. Fairseq HuBERT model operations
+2. RVC synthesizer model operations
+3. Some PyTorch operations fallback silently with incorrect results
+
+### Solution
+Force the entire RVC pipeline to run on **CPU** when MPS is detected. This is slower but produces correct audio output.
+
+### Files Modified for macOS Support
+
+#### 1. `server/voice_changer/RVC/pipeline/PipelineGenerator.py`
+```python
+def createPipeline(params, modelSlot, gpu, f0Detector):
+    dev = DeviceManager.get_instance().getDevice(gpu)
+    half = DeviceManager.get_instance().halfPrecisionAvailable(gpu)
+
+    # IMPORTANT: MPS backend produces garbage audio for RVC models.
+    # Force CPU for the entire pipeline on Mac until MPS issues are resolved.
+    if dev.type == "mps":
+        print("[PipelineGenerator] MPS detected - forcing CPU for entire pipeline")
+        dev = torch.device("cpu")
+        half = False
+    # ... rest of pipeline creation
+```
+
+#### 2. `server/voice_changer/RVC/pipeline/Pipeline.py`
+```python
+# Replaced CUDA-specific autocast with device-agnostic version
+from contextlib import nullcontext
+
+def _get_autocast_context(self):
+    """Get device-appropriate autocast context manager."""
+    if self.isHalf and self.device.type == "cuda":
+        from torch.cuda.amp import autocast
+        return autocast(enabled=True)
+    return nullcontext()
+```
+
+#### 3. `server/voice_changer/RVC/embedder/FairseqHubert.py`
+```python
+def loadModel(self, file, dev, isHalf=True):
+    # ... model loading ...
+
+    # Force CPU for HuBERT on MPS devices
+    if dev.type == "mps":
+        print("[FairseqHubert] MPS detected - forcing CPU for HuBERT")
+        self._use_cpu_for_inference = True
+        model = model.to(torch.device("cpu"))
+    else:
+        self._use_cpu_for_inference = False
+        model = model.to(dev)
+```
+
+#### 4. `server/voice_changer/RVC/inferencer/RVCInferencerv2Nono.py`
+```python
+def loadModel(self, file, gpu):
+    dev = DeviceManager.get_instance().getDevice(gpu)
+
+    # Force CPU for RVC inference on MPS devices
+    if dev.type == "mps":
+        print("[RVCInferencerv2Nono] MPS detected - forcing CPU for RVC inference")
+        dev = torch.device("cpu")
+        isHalf = False
+    # ... rest of model loading
+```
+
+#### 5. `server/restapi/MMVC_Rest.py`
+```python
+# Fixed PyInstaller check for running from source on Mac
+if sys.platform.startswith("darwin") and hasattr(sys, "_MEIPASS"):
+    # Running from PyInstaller bundle on macOS
+    p1 = os.path.dirname(sys._MEIPASS)
+```
+
+### Server Startup Log (macOS)
+When running on Mac, you should see these messages:
+```
+Device status:
+  CUDA devices: 0
+  MPS available: True
+
+[PipelineGenerator] MPS detected - forcing CPU for entire pipeline
+[RVCInferencerv2Nono] MPS detected - forcing CPU for RVC inference
+[FairseqHubert] MPS detected - forcing CPU for HuBERT
+```
+
+---
+
+## macOS Known Limitations
+
+| Limitation | Description | Workaround |
+|------------|-------------|------------|
+| No MPS acceleration | RVC runs on CPU | None (MPS produces incorrect results) |
+| Slower inference | CPU is ~2-5x slower than GPU | Use smaller chunk sizes |
+| No VoRAS model | Linux-only inferencer | Use standard RVC inferencer |
+| ONNX on CPU | No CoreML provider | Use PyTorch models for better CPU performance |
+| No FP16 | CPU uses FP32 only | Slightly higher memory usage |
+
+---
+
+## macOS Troubleshooting
+
+### "MPS available: False"
+1. Ensure you're on Apple Silicon (M1/M2/M3/M4), not Intel Mac
+2. Update macOS to latest version
+3. Reinstall PyTorch: `pip install --force-reinstall torch==2.0.1`
+
+### "Module not found" errors
+```bash
+# Ensure conda environment is activated
+conda activate vcclient
+```
+
+### Server crashes with MPS errors
+MPS fallback should handle this, but if crashes persist:
+```bash
+# Force CPU by setting GPU to -1 in the web UI
+# Or restart server (CPU is now default on Mac)
+```
+
+### Slow performance
+1. Use smaller chunk sizes in web UI settings
+2. Close other CPU-intensive applications
+3. Use ONNX pitch extractors (`rmvpe_onnx`) for better CPU utilization
+
+### Port already in use
+```bash
+# Find and kill process using port
+lsof -i :18888
+kill -9 <PID>
+
+# Or use different port
+PORT=8080 ./start-mac.sh
+```
+
+---
+
+## Pretrained Models
+
+Models are auto-downloaded from HuggingFace on first run. Stored in `server/pretrain/`:
+
+| Model | Size | Purpose |
+|-------|------|---------|
+| `hubert_base.pt` | ~360MB | Feature extraction (HuBERT) |
+| `content_vec_500.onnx` | ~100MB | Feature extraction (ONNX) |
+| `rmvpe.pt` | ~140MB | Pitch extraction |
+| `rmvpe.onnx` | ~140MB | Pitch extraction (ONNX) |
+| `crepe_onnx_full.onnx` | ~80MB | Pitch extraction (Crepe) |
+| `nsf_hifigan/` | ~55MB | Neural vocoder |
+
+---
+
+## Common Tasks
+
+### Adding a New Voice Model
+1. Create directory in `server/voice_changer/NewModel/`
+2. Implement `VoiceChangerModel` Protocol
+3. Add model type to `VoiceChangerType` in `const.py`
+4. Register in `VoiceChangerManager`
+5. Add UI support in `client/demo/`
+
+### Modifying REST Endpoints
+- Endpoints in `server/restapi/MMVC_Rest_VoiceChanger.py`
+- Update `ServerRestClient.ts` for client changes
+
+### Modifying Audio Processing
+- Server-side: `server/voice_changer/VoiceChanger.py` or model's `inference()`
+- Client-side: `client/lib/src/client/VoiceChangerWorkletNode.ts`
+
+### Adding UI Components
+- Components in `client/demo/src/components/`
+- Global state in `client/demo/src/001_globalHooks/`
+
+---
+
+## Testing
+
+Currently minimal test coverage. Run Python tests:
+```bash
+cd server
+pytest
+```
+
+---
+
+## Dependencies
+
+### Server (Key Python packages)
+| Package | Version | Purpose |
+|---------|---------|---------|
+| FastAPI | 0.95.1 | Web framework |
+| uvicorn | 0.21.1 | ASGI server |
+| python-socketio | 5.8.0 | Real-time communication |
+| torch | 2.0.1 | Deep learning |
+| torchaudio | 2.0.2 | Audio processing |
+| onnxruntime | 1.16.0 (Mac) / 1.13.1 (GPU) | Optimized inference |
+| librosa | 0.9.1 | Audio processing |
+| numpy | 1.23.5 | Numerical computing |
+| scipy | 1.10.1 | Scientific computing |
+| faiss-cpu | 1.7.3 | Vector similarity search |
+| torchcrepe | 0.0.18 | Pitch extraction |
+| torchfcpe | 0.0.3 | FCPE pitch extraction |
+
+### Client (Key npm packages)
+| Package | Purpose |
+|---------|---------|
+| React 18.2 | UI framework |
+| socket.io-client | Real-time communication |
+| amazon-chime-sdk-js | Audio processing utilities |
+| onnxruntime-web | Client-side inference |
+
+---
+
+## Notes for AI Agents
+
+### Critical Information
+1. **Primary language is Japanese** - README files, comments, and some code use Japanese. English translations in `docs_i18n/`.
+
+2. **RVC is the main model** - Most development focuses on RVC (Retrieval-based Voice Conversion). Other models have varying maintenance levels.
+
+3. **Real-time constraints** - Audio processing must be low-latency. Be careful with changes that add processing time.
+
+4. **macOS uses CPU only** - Despite MPS being detected, all RVC inference runs on CPU due to compatibility issues.
+
+5. **GPU support varies**:
+   - Linux/Windows: NVIDIA CUDA (best performance)
+   - macOS: CPU only (MPS produces incorrect results)
+   - ONNX: CPU on Mac, CUDA on Linux/Windows
+
+6. **Cross-platform** - Code must work on Windows, macOS (Apple Silicon), Linux, and Google Colab.
+
+7. **Model weights not in repo** - Pretrained models downloaded via HuggingFace on first run.
+
+### When Debugging macOS Issues
+1. Check if MPS fallback is enabled: `PYTORCH_ENABLE_MPS_FALLBACK=1`
+2. Verify CPU is being used (look for "forcing CPU" messages in logs)
+3. Check device consistency - all tensors must be on the same device
+4. Fairseq requires the custom fork for macOS compatibility
+
+### Performance Expectations
+| Platform | Inference Speed | Notes |
+|----------|-----------------|-------|
+| NVIDIA GPU | Real-time | Best performance |
+| Apple Silicon CPU | 2-5x slower | Functional but noticeable latency |
+| Intel CPU | 5-10x slower | May not be real-time |

--- a/README_mac.md
+++ b/README_mac.md
@@ -1,10 +1,12 @@
 # Voice-Changer on macOS (Apple Silicon)
 
-This guide explains how to run Voice-Changer natively on macOS with Apple Silicon (M1/M2/M3) using MPS (Metal Performance Shaders) for GPU acceleration.
+This guide explains how to run Voice-Changer natively on macOS with Apple Silicon (M1/M2/M3/M4).
+
+> **Note:** RVC inference runs on CPU due to MPS compatibility issues. While MPS is detected, the pipeline forces CPU execution to ensure correct audio output.
 
 ## Prerequisites
 
-- macOS with Apple Silicon (M1, M2, M3, etc.)
+- macOS with Apple Silicon (M1, M2, M3, M4, etc.)
 - [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/download)
 - Xcode Command Line Tools (install with `xcode-select --install`)
 
@@ -25,45 +27,57 @@ The web UI will be available at `https://localhost:18888`
 
 > **Note:** Accept the self-signed certificate warning in your browser on first access.
 
-## Manual Setup
+## Manual Setup (Tested & Verified)
 
-If you prefer to set up manually:
+These steps have been verified to work with pinned dependencies for reproducibility:
 
 ```bash
-# Create conda environment
+# 1. Create conda environment with Python 3.10
 conda create -n vcclient python=3.10 -y
+
+# 2. Activate the environment
 conda activate vcclient
 
-# Install PyTorch with MPS support
+# 3. Install PyTorch with MPS support first (must be installed before other deps)
 pip install torch==2.0.1 torchaudio==2.0.2
 
-# Install dependencies
+# 4. Navigate to server directory and install dependencies
 cd server
 pip install -r requirements-mac.txt
 
-# Start server
-python MMVCServerSIO.py -p 18888 --https true --model_dir model_dir
+# 5. Start the server
+PYTORCH_ENABLE_MPS_FALLBACK=1 python MMVCServerSIO.py -p 18888 --https true --model_dir model_dir
 ```
+
+### Dependency Pinning
+
+The `requirements-mac.txt` file contains all dependencies with exact pinned versions extracted from a working environment. This ensures reproducibility across different systems. Key dependencies include:
+
+- `torch==2.0.1` - PyTorch with MPS support
+- `onnxruntime==1.16.0` - CPU version (no GPU on Mac)
+- `fairseq` - Custom fork for macOS compatibility
+- `numpy==1.23.5` - Compatible with all audio processing libraries
 
 ## GPU Acceleration
 
-Voice-Changer automatically uses Apple's Metal Performance Shaders (MPS) for GPU acceleration on Apple Silicon Macs.
+While MPS (Metal Performance Shaders) is detected, RVC inference is forced to run on CPU to ensure correct audio output. This is a known compatibility issue with MPS and RVC models.
 
-### Verify MPS is Working
+### Verify Environment
 
 ```bash
 conda activate vcclient
 python -c "import torch; print(f'MPS available: {torch.backends.mps.is_available()}')"
 ```
 
-When the server starts, check the logs for:
+When the server starts, you'll see these log messages confirming CPU fallback:
 ```
-VoiceChangerV2 Initialized (GPU_NUM(cuda):0, mps_enabled:True, ...)
+VoiceChangerV2 Initialized (GPU_NUM(cuda):0, mps_enabled:True, onnx_device:CPU)
+[PipelineGenerator] MPS detected - forcing CPU for entire pipeline (known MPS compatibility issue)
 ```
 
-### GPU Usage
+### Current Status
 
-- **PyTorch models**: Use MPS (Metal) for GPU acceleration
+- **RVC models**: Run on CPU (MPS produces distorted audio)
 - **ONNX models**: Run on CPU (ONNX Runtime doesn't support Metal directly)
 
 ## Pretrained Models
@@ -107,8 +121,8 @@ python MMVCServerSIO.py -p 18888 --https false --model_dir model_dir
 
 ## Known Limitations
 
-1. **VoRAS model not supported** - VoRAS inference is not available on macOS
-2. **RVC runs on CPU** - RVC inference is forced to run on CPU due to MPS compatibility issues. This is slower than GPU but produces correct audio output.
+1. **RVC runs on CPU** - RVC inference is forced to CPU due to MPS compatibility issues. MPS produces incorrect/distorted audio ("ahhh" sound). CPU inference is slower but produces correct output.
+2. **VoRAS model not supported** - VoRAS inference is not available on macOS
 3. **ONNX runs on CPU** - ONNX Runtime uses CPU; CoreML provider not currently supported
 4. **No half-precision (FP16)** - CPU inference uses FP32
 5. **First run is slow** - Downloads ~500MB+ of pretrained models
@@ -127,13 +141,12 @@ python MMVCServerSIO.py -p 18888 --https false --model_dir model_dir
 2. Update macOS to latest version
 3. Reinstall PyTorch: `pip install --force-reinstall torch==2.0.1`
 
-### Server crashes with MPS errors
+### Distorted "ahhhh" audio output
 
-Try running with CPU fallback:
-```bash
-python MMVCServerSIO.py -p 18888 --https true --model_dir model_dir
-# Then set GPU to -1 in the web UI
-```
+This was a known MPS issue that has been fixed. The pipeline now automatically forces CPU execution when MPS is detected. If you still experience this:
+1. Ensure you're using the latest code with the MPS fixes
+2. Check the logs for: `[PipelineGenerator] MPS detected - forcing CPU for entire pipeline`
+3. If the message doesn't appear, the fix may not be applied correctly
 
 ### "Module not found" errors
 
@@ -169,16 +182,19 @@ PORT=8080 ./start-mac.sh
 
 ## Comparison: Mac vs CUDA
 
-| Feature | Mac (MPS) | NVIDIA (CUDA) |
-|---------|-----------|---------------|
-| PyTorch inference | MPS GPU | CUDA GPU |
+| Feature | Mac (Apple Silicon) | NVIDIA (CUDA) |
+|---------|---------------------|---------------|
+| RVC inference | CPU (forced) | CUDA GPU |
 | ONNX inference | CPU | CUDA GPU |
 | Half-precision | No (FP32) | Yes (FP16) |
 | VoRAS model | No | Yes |
-| Performance | Good | Best |
+| Performance | Slower (CPU) | Best (GPU) |
+
+> **Why CPU on Mac?** MPS backend produces numerically incorrect results for RVC models, resulting in distorted "ahhhh" audio. CPU inference is slower but produces correct voice conversion.
 
 ## Files Created
 
-- `server/requirements-mac.txt` - Mac-specific dependencies
+- `server/requirements-mac.txt` - Mac-specific dependencies (all versions pinned)
 - `server/setup-mac.sh` - Environment setup script
 - `server/start-mac.sh` - Server startup script
+- `Claude.md` - Comprehensive codebase documentation

--- a/README_mac.md
+++ b/README_mac.md
@@ -1,0 +1,184 @@
+# Voice-Changer on macOS (Apple Silicon)
+
+This guide explains how to run Voice-Changer natively on macOS with Apple Silicon (M1/M2/M3) using MPS (Metal Performance Shaders) for GPU acceleration.
+
+## Prerequisites
+
+- macOS with Apple Silicon (M1, M2, M3, etc.)
+- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/download)
+- Xcode Command Line Tools (install with `xcode-select --install`)
+
+## Quick Start
+
+```bash
+# 1. Navigate to server directory
+cd server
+
+# 2. Run setup script (creates conda environment)
+./setup-mac.sh
+
+# 3. Start the server
+./start-mac.sh
+```
+
+The web UI will be available at `https://localhost:18888`
+
+> **Note:** Accept the self-signed certificate warning in your browser on first access.
+
+## Manual Setup
+
+If you prefer to set up manually:
+
+```bash
+# Create conda environment
+conda create -n vcclient python=3.10 -y
+conda activate vcclient
+
+# Install PyTorch with MPS support
+pip install torch==2.0.1 torchaudio==2.0.2
+
+# Install dependencies
+cd server
+pip install -r requirements-mac.txt
+
+# Start server
+python MMVCServerSIO.py -p 18888 --https true --model_dir model_dir
+```
+
+## GPU Acceleration
+
+Voice-Changer automatically uses Apple's Metal Performance Shaders (MPS) for GPU acceleration on Apple Silicon Macs.
+
+### Verify MPS is Working
+
+```bash
+conda activate vcclient
+python -c "import torch; print(f'MPS available: {torch.backends.mps.is_available()}')"
+```
+
+When the server starts, check the logs for:
+```
+VoiceChangerV2 Initialized (GPU_NUM(cuda):0, mps_enabled:True, ...)
+```
+
+### GPU Usage
+
+- **PyTorch models**: Use MPS (Metal) for GPU acceleration
+- **ONNX models**: Run on CPU (ONNX Runtime doesn't support Metal directly)
+
+## Pretrained Models
+
+Pretrained models are automatically downloaded on first run from HuggingFace:
+
+| Model | Size | Purpose |
+|-------|------|---------|
+| hubert_base.pt | ~360MB | Feature extraction |
+| content_vec_500.onnx | ~100MB | Feature extraction (ONNX) |
+| rmvpe.pt | ~140MB | Pitch extraction |
+| crepe_onnx_full.onnx | ~80MB | Pitch extraction (ONNX) |
+| nsf_hifigan | ~55MB | Neural vocoder |
+
+Models are stored in `server/pretrain/`.
+
+## RVC Models
+
+Place your RVC voice models in `server/model_dir/`. Supported formats:
+- `.pth` files (PyTorch)
+- `.onnx` files (ONNX - recommended for faster inference)
+
+## Configuration
+
+### Change Port
+
+```bash
+PORT=8080 ./start-mac.sh
+```
+
+Or pass directly:
+```bash
+python MMVCServerSIO.py -p 8080 --https true --model_dir model_dir
+```
+
+### Disable HTTPS
+
+```bash
+python MMVCServerSIO.py -p 18888 --https false --model_dir model_dir
+```
+
+## Known Limitations
+
+1. **VoRAS model not supported** - VoRAS inference is not available on macOS
+2. **RVC runs on CPU** - RVC inference is forced to run on CPU due to MPS compatibility issues. This is slower than GPU but produces correct audio output.
+3. **ONNX runs on CPU** - ONNX Runtime uses CPU; CoreML provider not currently supported
+4. **No half-precision (FP16)** - CPU inference uses FP32
+5. **First run is slow** - Downloads ~500MB+ of pretrained models
+
+## RVC Model Notes
+
+- **"nono" models** (no f0): These models don't support pitch shifting. They convert voice timbre only.
+- **f0 models**: Support pitch shifting via the "tran" parameter. May sound more natural.
+- **Index files** (`.index`): Use `indexRatio > 0` to enable index-based voice similarity matching for better quality.
+
+## Troubleshooting
+
+### "MPS available: False"
+
+1. Ensure you're on Apple Silicon (M1/M2/M3), not Intel Mac
+2. Update macOS to latest version
+3. Reinstall PyTorch: `pip install --force-reinstall torch==2.0.1`
+
+### Server crashes with MPS errors
+
+Try running with CPU fallback:
+```bash
+python MMVCServerSIO.py -p 18888 --https true --model_dir model_dir
+# Then set GPU to -1 in the web UI
+```
+
+### "Module not found" errors
+
+Ensure the conda environment is activated:
+```bash
+conda activate vcclient
+```
+
+### Slow performance
+
+1. Use ONNX models when available (`.onnx` files)
+2. Reduce chunk size in web UI settings
+3. Close other GPU-intensive applications
+
+### Port already in use
+
+```bash
+# Find process using port
+lsof -i :18888
+
+# Kill process
+kill -9 <PID>
+
+# Or use different port
+PORT=8080 ./start-mac.sh
+```
+
+## Performance Tips
+
+1. **Use ONNX RMVPE** - Set pitch extractor to `rmvpe_onnx` for better CPU utilization
+2. **Optimize chunk size** - Start with default, adjust based on latency vs quality
+3. **Monitor Activity Monitor** - Check GPU usage under "GPU History"
+
+## Comparison: Mac vs CUDA
+
+| Feature | Mac (MPS) | NVIDIA (CUDA) |
+|---------|-----------|---------------|
+| PyTorch inference | MPS GPU | CUDA GPU |
+| ONNX inference | CPU | CUDA GPU |
+| Half-precision | No (FP32) | Yes (FP16) |
+| VoRAS model | No | Yes |
+| Performance | Good | Best |
+
+## Files Created
+
+- `server/requirements-mac.txt` - Mac-specific dependencies
+- `server/setup-mac.sh` - Environment setup script
+- `server/start-mac.sh` - Server startup script

--- a/server/requirements-mac.txt
+++ b/server/requirements-mac.txt
@@ -1,0 +1,31 @@
+# Requirements for macOS (Apple Silicon with MPS support)
+# Use this instead of requirements.txt on Mac
+
+uvicorn==0.21.1
+pyOpenSSL==23.1.1
+numpy==1.23.5
+torch==2.0.1
+torchaudio==2.0.2
+resampy==0.4.2
+python-socketio==5.8.0
+fastapi==0.95.1
+python-multipart==0.0.6
+# Use onnxruntime (CPU) instead of onnxruntime-gpu on Mac
+onnxruntime==1.16.0
+scipy==1.10.1
+matplotlib==3.7.1
+websockets==11.0.2
+faiss-cpu==1.7.3
+torchcrepe==0.0.18
+librosa==0.9.1
+gin==0.1.6
+gin_config==0.5.0
+einops==0.6.0
+local_attention==1.8.5
+sounddevice==0.4.6
+dataclasses_json==0.5.7
+onnxsim==0.4.28
+torchfcpe==0.0.3
+# fairseq for HuBERT embedder (use fork for macOS compatibility)
+fairseq @ git+https://github.com/brandonkovacs/fairseq.git
+pyworld==0.3.5

--- a/server/requirements-mac.txt
+++ b/server/requirements-mac.txt
@@ -1,31 +1,101 @@
-# Requirements for macOS (Apple Silicon with MPS support)
-# Use this instead of requirements.txt on Mac
+# Requirements for macOS (Apple Silicon) - Voice-Changer
+# Tested on: macOS with Apple Silicon (M1/M2/M3/M4), Python 3.10
+# Generated from working environment - all versions pinned for reproducibility
 
+# =============================================================================
+# Core Framework
+# =============================================================================
+fastapi==0.95.1
 uvicorn==0.21.1
-pyOpenSSL==23.1.1
-numpy==1.23.5
+python-socketio==5.8.0
+python-multipart==0.0.6
+starlette==0.26.1
+
+# =============================================================================
+# PyTorch & Deep Learning (MPS-compatible versions)
+# =============================================================================
 torch==2.0.1
 torchaudio==2.0.2
-resampy==0.4.2
-python-socketio==5.8.0
-fastapi==0.95.1
-python-multipart==0.0.6
-# Use onnxruntime (CPU) instead of onnxruntime-gpu on Mac
-onnxruntime==1.16.0
-scipy==1.10.1
-matplotlib==3.7.1
-websockets==11.0.2
-faiss-cpu==1.7.3
 torchcrepe==0.0.18
-librosa==0.9.1
-gin==0.1.6
-gin_config==0.5.0
-einops==0.6.0
-local_attention==1.8.5
-sounddevice==0.4.6
-dataclasses_json==0.5.7
-onnxsim==0.4.28
 torchfcpe==0.0.3
-# fairseq for HuBERT embedder (use fork for macOS compatibility)
-fairseq @ git+https://github.com/brandonkovacs/fairseq.git
+
+# =============================================================================
+# ONNX Runtime (CPU version for macOS - no GPU support)
+# =============================================================================
+onnxruntime==1.16.0
+onnx==1.20.1
+onnxsim==0.4.28
+
+# =============================================================================
+# Audio Processing
+# =============================================================================
+librosa==0.9.1
+resampy==0.4.2
+sounddevice==0.4.6
+soundfile==0.13.1
 pyworld==0.3.5
+audioread==3.1.0
+
+# =============================================================================
+# Scientific Computing
+# =============================================================================
+numpy==1.23.5
+scipy==1.10.1
+scikit-learn==1.7.2
+numba==0.63.1
+llvmlite==0.46.0
+
+# =============================================================================
+# Vector Search (for RVC index files)
+# =============================================================================
+faiss-cpu==1.7.3
+
+# =============================================================================
+# Visualization & Utils
+# =============================================================================
+matplotlib==3.7.1
+tqdm==4.67.1
+
+# =============================================================================
+# Configuration & Serialization
+# =============================================================================
+PyYAML==6.0.3
+dataclasses-json==0.5.7
+omegaconf==2.3.0
+hydra-core==1.3.2
+gin==0.1.6
+gin-config==0.5.0
+
+# =============================================================================
+# Networking & Security
+# =============================================================================
+pyOpenSSL==23.1.1
+websockets==11.0.2
+requests==2.32.5
+cryptography==40.0.2
+
+# =============================================================================
+# Deep Learning Utilities
+# =============================================================================
+einops==0.6.0
+local-attention==1.8.5
+
+# =============================================================================
+# Fairseq (HuBERT embedder) - Custom fork for macOS compatibility
+# =============================================================================
+fairseq @ git+https://github.com/brandonkovacs/fairseq.git
+
+# =============================================================================
+# Additional Dependencies (required by above packages)
+# =============================================================================
+Cython==3.2.4
+protobuf==6.33.4
+pydantic==1.10.26
+regex==2026.1.14
+sacrebleu==2.6.0
+tabulate==0.9.0
+rich==14.2.0
+coloredlogs==15.0.1
+portalocker==3.2.0
+bitarray==3.8.0
+lxml==6.0.2

--- a/server/restapi/MMVC_Rest.py
+++ b/server/restapi/MMVC_Rest.py
@@ -80,7 +80,8 @@ class MMVC_Rest:
             except Exception as e:
                 print("Locating model_dir_static failed", e)
 
-            if sys.platform.startswith("darwin"):
+            if sys.platform.startswith("darwin") and hasattr(sys, "_MEIPASS"):
+                # Running from PyInstaller bundle on macOS
                 p1 = os.path.dirname(sys._MEIPASS)
                 p2 = os.path.dirname(p1)
                 p3 = os.path.dirname(p2)
@@ -92,6 +93,7 @@ class MMVC_Rest:
                     name="static",
                 )
             else:
+                # Running from source (all platforms) or non-bundled macOS
                 app_fastapi.mount(
                     f"/{voiceChangerParams.model_dir}",
                     StaticFiles(directory=voiceChangerParams.model_dir),

--- a/server/setup-mac.sh
+++ b/server/setup-mac.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Setup script for Voice-Changer on macOS (Apple Silicon)
+# Creates conda environment with Python 3.10 and installs dependencies
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_NAME="vcclient"
+
+echo "=== Voice-Changer macOS Setup ==="
+echo ""
+
+# Check if conda is available
+if ! command -v conda &> /dev/null; then
+    echo "Error: conda not found. Please install Miniconda or Anaconda first."
+    echo "Download from: https://docs.conda.io/en/latest/miniconda.html"
+    exit 1
+fi
+
+# Initialize conda for bash
+eval "$(conda shell.bash hook)"
+
+# Check if environment already exists
+if conda env list | grep -q "^${ENV_NAME} "; then
+    echo "Conda environment '${ENV_NAME}' already exists."
+    read -p "Do you want to recreate it? (y/N) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Removing existing environment..."
+        conda env remove -n ${ENV_NAME} -y
+    else
+        echo "Using existing environment."
+        conda activate ${ENV_NAME}
+        echo ""
+        echo "To start the server, run: ./start-mac.sh"
+        exit 0
+    fi
+fi
+
+echo ""
+echo "Creating conda environment '${ENV_NAME}' with Python 3.10..."
+conda create -n ${ENV_NAME} python=3.10 -y
+
+echo ""
+echo "Activating environment..."
+conda activate ${ENV_NAME}
+
+echo ""
+echo "Installing PyTorch with MPS (Metal) support..."
+pip install torch==2.0.1 torchaudio==2.0.2
+
+echo ""
+echo "Installing remaining dependencies..."
+pip install -r "${SCRIPT_DIR}/requirements-mac.txt"
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "MPS (Metal) availability:"
+python -c "import torch; print(f'  MPS available: {torch.backends.mps.is_available()}')"
+python -c "import torch; print(f'  MPS built: {torch.backends.mps.is_built()}')"
+echo ""
+echo "To start the server:"
+echo "  cd ${SCRIPT_DIR}"
+echo "  ./start-mac.sh"
+echo ""
+echo "Or manually:"
+echo "  conda activate ${ENV_NAME}"
+echo "  python MMVCServerSIO.py -p 18888 --https true"

--- a/server/start-mac.sh
+++ b/server/start-mac.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Start script for Voice-Changer on macOS (Apple Silicon)
+# Activates conda environment and starts the server
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_NAME="vcclient"
+PORT="${PORT:-18888}"
+
+echo "=== Voice-Changer macOS Server ==="
+echo ""
+
+# Initialize conda for bash
+eval "$(conda shell.bash hook)"
+
+# Check if environment exists
+if ! conda env list | grep -q "^${ENV_NAME} "; then
+    echo "Error: Conda environment '${ENV_NAME}' not found."
+    echo "Please run setup-mac.sh first:"
+    echo "  ./setup-mac.sh"
+    exit 1
+fi
+
+echo "Activating conda environment '${ENV_NAME}'..."
+conda activate ${ENV_NAME}
+
+# Show MPS status
+echo ""
+echo "Device status:"
+python -c "import torch; print(f'  CUDA devices: {torch.cuda.device_count()}')"
+python -c "import torch; print(f'  MPS available: {torch.backends.mps.is_available()}')"
+echo ""
+
+# Enable MPS fallback to CPU for unsupported operations
+# Some PyTorch ops (like weight_norm) aren't implemented for MPS yet
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+
+# Create model directory if it doesn't exist
+mkdir -p "${SCRIPT_DIR}/model_dir"
+mkdir -p "${SCRIPT_DIR}/pretrain"
+
+echo "Starting server on port ${PORT}..."
+echo "Web UI will be available at: https://localhost:${PORT}"
+echo "(Accept the self-signed certificate warning in your browser)"
+echo ""
+echo "Press Ctrl+C to stop the server"
+echo ""
+
+# Start the server
+# Pretrained models will be auto-downloaded on first run
+cd "${SCRIPT_DIR}"
+python MMVCServerSIO.py \
+    -p ${PORT} \
+    --https true \
+    --model_dir model_dir \
+    --content_vec_500 pretrain/checkpoint_best_legacy_500.pt \
+    --content_vec_500_onnx pretrain/content_vec_500.onnx \
+    --content_vec_500_onnx_on true \
+    --hubert_base pretrain/hubert_base.pt \
+    --hubert_base_jp pretrain/rinna_hubert_base_jp.pt \
+    --hubert_soft pretrain/hubert/hubert-soft-0d54a1f4.pt \
+    --nsf_hifigan pretrain/nsf_hifigan/model \
+    --crepe_onnx_full pretrain/crepe_onnx_full.onnx \
+    --crepe_onnx_tiny pretrain/crepe_onnx_tiny.onnx \
+    --rmvpe pretrain/rmvpe.pt \
+    --rmvpe_onnx pretrain/rmvpe.onnx \
+    "$@"

--- a/server/voice_changer/RVC/embedder/FairseqHubert.py
+++ b/server/voice_changer/RVC/embedder/FairseqHubert.py
@@ -15,9 +15,18 @@ class FairseqHubert(Embedder):
         model = models[0]
         model.eval()
 
-        model = model.to(dev)
-        if isHalf:
-            model = model.half()
+        # IMPORTANT: Fairseq HuBERT doesn't work correctly on MPS (produces garbage features).
+        # Force CPU execution for the embedder on MPS devices.
+        # The RVC inferencer can still use MPS for the actual voice conversion.
+        if dev.type == "mps":
+            print("[FairseqHubert] MPS detected - forcing CPU for HuBERT (known MPS compatibility issue)", flush=True)
+            self._use_cpu_for_inference = True
+            model = model.to(torch.device("cpu"))
+        else:
+            self._use_cpu_for_inference = False
+            model = model.to(dev)
+            if isHalf:
+                model = model.half()
 
         self.model = model
         return self
@@ -25,13 +34,21 @@ class FairseqHubert(Embedder):
     def extractFeatures(
         self, feats: torch.Tensor, embOutputLayer=9, useFinalProj=True
     ) -> torch.Tensor:
-        padding_mask = torch.BoolTensor(feats.shape).to(self.dev).fill_(False)
+        # For MPS devices, run embedder on CPU then move result back
+        if getattr(self, '_use_cpu_for_inference', False):
+            inference_dev = torch.device("cpu")
+            output_dev = self.dev  # Original MPS device
+        else:
+            inference_dev = self.dev
+            output_dev = self.dev
+
+        padding_mask = torch.BoolTensor(feats.shape).to(inference_dev).fill_(False)
 
         # オリジナル_v1は L9にfinal_projをかけていた。(-> 256)
         # オリジナル_v2は L12にfinal_projをかけない。(-> 768)
 
         inputs = {
-            "source": feats.to(self.dev),
+            "source": feats.to(inference_dev),
             "padding_mask": padding_mask,
             "output_layer": embOutputLayer,  # 9 or 12
         }
@@ -42,4 +59,9 @@ class FairseqHubert(Embedder):
                 feats = self.model.final_proj(logits[0])
             else:
                 feats = logits[0]
+
+        # Move features back to original device (MPS) for downstream processing
+        if output_dev != inference_dev:
+            feats = feats.to(output_dev)
+
         return feats

--- a/server/voice_changer/RVC/inferencer/RVCInferencerv2Nono.py
+++ b/server/voice_changer/RVC/inferencer/RVCInferencerv2Nono.py
@@ -13,6 +13,13 @@ class RVCInferencerv2Nono(Inferencer):
         dev = DeviceManager.get_instance().getDevice(gpu)
         isHalf = DeviceManager.get_instance().halfPrecisionAvailable(gpu)
 
+        # IMPORTANT: RVC model doesn't work correctly on MPS (produces garbage audio).
+        # Force CPU execution on Mac until MPS compatibility is resolved.
+        if dev.type == "mps":
+            print("[RVCInferencerv2Nono] MPS detected - forcing CPU for RVC inference (known MPS compatibility issue)", flush=True)
+            dev = torch.device("cpu")
+            isHalf = False  # CPU doesn't benefit from half precision
+
         cpt = torch.load(file, map_location="cpu")
         model = SynthesizerTrnMs768NSFsid_nono(*cpt["config"], is_half=isHalf)
 
@@ -24,6 +31,7 @@ class RVCInferencerv2Nono(Inferencer):
             model = model.half()
 
         self.model = model
+        self._device = dev  # Store for inference
         return self
 
     def infer(
@@ -35,6 +43,12 @@ class RVCInferencerv2Nono(Inferencer):
         sid: torch.Tensor,
         convert_length: int | None,
     ) -> torch.Tensor:
+        # Ensure inputs are on the correct device
+        dev = getattr(self, '_device', feats.device)
+        feats = feats.to(dev)
+        pitch_length = pitch_length.to(dev)
+        sid = sid.to(dev)
+
         res = self.model.infer(feats, pitch_length, sid, convert_length=convert_length)
         res = res[0][0, 0].to(dtype=torch.float32)
         res = torch.clip(res, -1.0, 1.0)

--- a/server/voice_changer/RVC/pipeline/Pipeline.py
+++ b/server/voice_changer/RVC/pipeline/Pipeline.py
@@ -3,7 +3,7 @@ from typing import Any
 import math
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from contextlib import nullcontext
 from Exceptions import (
     DeviceCannotSupportHalfPrecisionException,
     DeviceChangingException,
@@ -65,6 +65,17 @@ class Pipeline(object):
         self.sr = 16000
         self.window = 160
 
+    def _get_autocast_context(self):
+        """Get device-appropriate autocast context manager.
+
+        CUDA autocast (torch.cuda.amp.autocast) doesn't work on MPS devices.
+        Only use autocast for CUDA devices with half precision enabled.
+        """
+        if self.isHalf and self.device.type == "cuda":
+            from torch.cuda.amp import autocast
+            return autocast(enabled=True)
+        return nullcontext()
+
     def getPipelineInfo(self):
         inferencerInfo = self.inferencer.getInferencerInfo() if self.inferencer else {}
         embedderInfo = self.embedder.getEmbedderInfo()
@@ -100,7 +111,7 @@ class Pipeline(object):
         return pitch, pitchf
 
     def extractFeatures(self, feats, embOutputLayer, useFinalProj):
-        with autocast(enabled=self.isHalf):
+        with self._get_autocast_context():
             try:
                 feats = self.embedder.extractFeatures(feats, embOutputLayer, useFinalProj)
                 if torch.isnan(feats).all():
@@ -117,8 +128,8 @@ class Pipeline(object):
     def infer(self, feats, p_len, pitch, pitchf, sid, out_size):
         try:
             with torch.no_grad():
-                with autocast(enabled=self.isHalf):
-                    audio1 = self.inferencer.infer(feats,  p_len, pitch, pitchf, sid, out_size)                    
+                with self._get_autocast_context():
+                    audio1 = self.inferencer.infer(feats,  p_len, pitch, pitchf, sid, out_size)
                     audio1 = (audio1 * 32767.5).data.to(dtype=torch.int16)
             return audio1
         except RuntimeError as e:
@@ -229,7 +240,8 @@ class Pipeline(object):
             # pitchの推定が上手くいかない(pitchf=0)場合、検索前の特徴を混ぜる
             # pitchffの作り方の疑問はあるが、本家通りなので、このまま使うことにする。
             # https://github.com/w-okada/voice-changer/pull/276#issuecomment-1571336929
-            if protect < 0.5 and search_index:
+            # Also check pitchf is not None for "nono" (no f0) models
+            if protect < 0.5 and search_index and pitchf is not None:
                 pitchff = pitchf.clone()
                 pitchff[pitchf > 0] = 1
                 pitchff[pitchf < 1] = protect

--- a/server/voice_changer/RVC/pipeline/PipelineGenerator.py
+++ b/server/voice_changer/RVC/pipeline/PipelineGenerator.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+import torch
 import faiss
 from Exceptions import PipelineCreateException
 from data.ModelSlot import RVCModelSlot
@@ -15,6 +16,13 @@ from voice_changer.utils.VoiceChangerParams import VoiceChangerParams
 def createPipeline(params: VoiceChangerParams, modelSlot: RVCModelSlot, gpu: int, f0Detector: str):
     dev = DeviceManager.get_instance().getDevice(gpu)
     half = DeviceManager.get_instance().halfPrecisionAvailable(gpu)
+
+    # IMPORTANT: MPS backend produces garbage audio for RVC models.
+    # Force CPU for the entire pipeline on Mac until MPS issues are resolved.
+    if dev.type == "mps":
+        print("[PipelineGenerator] MPS detected - forcing CPU for entire pipeline (known MPS compatibility issue)", flush=True)
+        dev = torch.device("cpu")
+        half = False
 
     # Inferencer 生成
     try:


### PR DESCRIPTION
## Summary

This PR adds native macOS Apple Silicon (M1/M2/M3/M4) support for Voice-Changer, enabling RVC voice conversion to run without Docker.

### Key Changes

- **Force CPU inference for RVC pipeline** - MPS (Metal Performance Shaders) produces numerically incorrect results causing distorted "ahhhh" audio output. The pipeline now automatically detects MPS and forces CPU execution for correct audio.
- **Device-agnostic autocast** - Replaced CUDA-specific `torch.cuda.amp.autocast` with a device-agnostic implementation using `nullcontext` for non-CUDA devices.
- **Mac-specific dependencies** - Created `requirements-mac.txt` with CPU-only ONNX Runtime and all versions pinned for reproducibility.
- **Setup and startup scripts** - Added `setup-mac.sh` and `start-mac.sh` for easy environment configuration.
- **Comprehensive documentation** - Added `README_mac.md` with verified setup instructions and `Claude.md` with detailed codebase documentation.

## Technical Details

### The MPS Audio Problem

When running RVC inference on Apple Silicon using MPS backend, the output audio was severely distorted - a repeating "ahhhh" sound instead of the converted voice. Investigation revealed that MPS produces numerically incorrect results for the RVC model operations.

### Solution: CPU Fallback

The fix forces the entire RVC pipeline to CPU when MPS is detected:

**`PipelineGenerator.py`** (primary fix):
```python
if dev.type == "mps":
    print("[PipelineGenerator] MPS detected - forcing CPU for entire pipeline")
    dev = torch.device("cpu")
    half = False
```

**`FairseqHubert.py`** (embedder):
```python
if dev.type == "mps":
    self._use_cpu_for_inference = True
    model = model.to(torch.device("cpu"))
```

**`RVCInferencerv2Nono.py`** (inferencer):
```python
if dev.type == "mps":
    dev = torch.device("cpu")
    isHalf = False
```

**`Pipeline.py`** (autocast fix):
```python
def _get_autocast_context(self):
    if self.isHalf and self.device.type == "cuda":
        from torch.cuda.amp import autocast
        return autocast(enabled=True)
    return nullcontext()
```

### Files Changed

| File | Purpose |
|------|---------|
| `server/voice_changer/RVC/pipeline/PipelineGenerator.py` | Force CPU for entire pipeline on MPS |
| `server/voice_changer/RVC/pipeline/Pipeline.py` | Device-agnostic autocast |
| `server/voice_changer/RVC/embedder/FairseqHubert.py` | Force CPU for HuBERT embedder |
| `server/voice_changer/RVC/inferencer/RVCInferencerv2Nono.py` | Force CPU for RVC inferencer |
| `server/restapi/MMVC_Rest.py` | Fix PyInstaller detection for macOS |
| `server/requirements-mac.txt` | Mac dependencies with pinned versions |
| `server/setup-mac.sh` | Conda environment setup script |
| `server/start-mac.sh` | Server startup script |
| `README_mac.md` | User documentation |
| `Claude.md` | Codebase documentation |

## Known Limitations

1. **RVC runs on CPU** - Slower than GPU but produces correct audio
2. **VoRAS model not supported** - Not available on macOS
3. **ONNX runs on CPU** - ONNX Runtime doesn't support Metal
4. **No half-precision (FP16)** - CPU inference uses FP32

## Test Plan

- [x] Create fresh conda environment with Python 3.10
- [x] Install PyTorch 2.0.1 with MPS support
- [x] Install dependencies from `requirements-mac.txt`
- [x] Verify MPS is detected: `torch.backends.mps.is_available() == True`
- [x] Start server and verify CPU fallback messages in logs
- [x] Test RVC voice conversion produces correct audio output

## Verification

When running on macOS, the server logs should show:
```
VoiceChangerV2 Initialized (GPU_NUM(cuda):0, mps_enabled:True, onnx_device:CPU)
[PipelineGenerator] MPS detected - forcing CPU for entire pipeline (known MPS compatibility issue)
```

🤖 Generated with [Claude Code](https://claude.ai/code)